### PR TITLE
Re-applying custom changes to actions/cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,8 @@ outputs:
 runs:
   using: 'node16'
   main: 'dist/restore/index.js'
-  post: 'dist/save/index.js'
-  post-if: success()
+  # post: 'dist/save/index.js' # MODIFIED BY theScore
+  # post-if: success() # MODIFIED BY theScore
 branding:
   icon: 'archive'
   color: 'gray-dark'

--- a/src/restoreImpl.ts
+++ b/src/restoreImpl.ts
@@ -26,6 +26,8 @@ async function restoreImpl(
 
         const primaryKey = core.getInput(Inputs.Key, { required: true });
         stateProvider.setState(State.CachePrimaryKey, primaryKey);
+        // MODIFIED BY theScore
+        // the line above was commented https://github.com/actions/cache/commit/db214e33faf6d675110901cb292681a6fced5870
 
         const restoreKeys = utils.getInputAsArray(Inputs.RestoreKeys);
         const cachePaths = utils.getInputAsArray(Inputs.Path, {


### PR DESCRIPTION
1st this PR https://github.com/scorebet/action-readonly-cache/pull/1

Re-applying these customisations: 

- https://github.com/actions/cache/commit/db214e33faf6d675110901cb292681a6fced5870
- https://github.com/actions/cache/commit/7e13e8b58a9e01272de1a734a9b66d58db200b56